### PR TITLE
Reset the img url

### DIFF
--- a/src/visual.ts
+++ b/src/visual.ts
@@ -49,6 +49,8 @@ module powerbi.extensibility.visual {
             let imageURL: string | null = null;
             let altText: string = "";
 
+            this.imgElement.src = "";
+
             if (options.dataViews[0].tree.root.children[0].values[0].value) {
                 imageURL = options.dataViews[0].tree.root.children[0].values[0].value.toString();
             }


### PR DESCRIPTION
When the data source reloads the image needs to refresh also. Previously, the image only refreshed on tab change, not on data change. The img url needs to be reset each update.